### PR TITLE
Adding a verbose option to the script

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,4 +14,5 @@ Pre-compiled binaries are available in the [latest release page](https://github.
   --pin             whether or not to pin the data (default true)
   --secret string   your Infura ProjectSecret
   --url string      the API URL (default "https://ipfs.infura.io:5001")
+  --verbose         whether or not to print full upload information (default false)
 ```

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ func main() {
 	projectSecret := flag.String("secret", "", "your Infura ProjectSecret")
 	api := flag.String("url", infuraAPI, "the API URL")
 	pin := flag.Bool("pin", true, "whether or not to pin the data")
+	verbose := flag.Bool("verbose", false, "whether or not to print full upload information")
 
 	flag.Parse()
 
@@ -99,7 +100,11 @@ func main() {
 		}
 
 		if output.Path != nil && output.Name != "" {
-			_, _ = fmt.Fprintln(os.Stderr, fmt.Sprintf("Added %v", output.Name))
+			if *verbose {
+				_, _ = fmt.Fprintln(os.Stderr, fmt.Sprintf("Added %v %v | Bytes: %v | Size: %v", output.Name, output.Path, output.Bytes, output.Size))
+			} else {
+				_, _ = fmt.Fprintln(os.Stderr, fmt.Sprintf("Added %v", output.Name))
+			}
 		}
 	}
 


### PR DESCRIPTION
Why:
 - Adding a `--verbose` option to the script. 
 - With this option enabled it's possible to check all information coming for the upload of each file. 
 - This may come in handy if the script fails and we want to check CIDs for the ones that were uploaded, or just store the output to retrieve all individual CIDs. 

How:
- Defaulting to false. In this case, it should only print the filename.
- If `verbose` is enabled then print `Name`, `Path`, `Size`, and `Bytes`.